### PR TITLE
Add stale config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,16 +1,13 @@
-# Number of days of inactivity before an issue becomes stale
 daysUntilStale: 60
-# Number of days of inactivity before a stale issue is closed
+
 daysUntilClose: 7
-# Issues with these labels will never be considered stale
+
 exemptLabels:
   - "➡️ Tracking"
-# Label to use when marking an issue as stale
+
 staleLabel: wontfix
-# Comment to post when marking an issue as stale. Set to `false` to disable
+
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity and is not currently being tracked. If it still needs to be addressed,
-  please leave a comment and provide additional details, if necessary.
-# Comment to post when closing a stale issue. Set to `false` to disable
+  Is this still causing friction? If so, please comment with any updates or addition details.
+  
 closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,16 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "➡️ Tracking"
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity and is not currently being tracked. If it still needs to be addressed,
+  please leave a comment and provide additional details, if necessary.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Adding a stale config to this repo. I created a tracking label and made that exempt, thinking that we'd want to leave any Issues open that are referenced elsewhere.

Looks like emojis work in the config by dropping the unicode character in between `""`: https://github.com/wix/detox/blob/8a45438ce1b6bfe3a7b7a4b7d5f78efd56134270/.github/stale.yml#L23